### PR TITLE
Add retry logic & rate limit handling

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -26,7 +26,7 @@ This document outlines the planned features and milestones for `gh-as-db`.
 - [x] **Middleware Support**: Hooks for data validation or transformation.
 - [x] **Improve Tests**: Add more tests and improve test coverage.
 - [x] **Improve Performance**: Optimize performance and reduce memory usage via conditional GET caching.
-- [ ] **Improve Error Handling**: Add more error handling and improve error messages.
+- [x] **Improve Error Handling**: Retry with exponential backoff for transient errors (429, 5xx), `RateLimitError`, and `Retry-After` header support.
 - [ ] **Improve Logging**: Add more logging and improve logging messages.
 - [x] **Improve Documentation**: Add more documentation and improve documentation.
 - [x] **Comprehensive Documentation**: Detailed API reference and tutorials.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gh-as-db",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Use a private GitHub repository as a database for your application.",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,9 +1,16 @@
+export interface RetryConfig {
+  maxRetries?: number; // Default: 3
+  baseDelay?: number; // Default: 1000ms
+  maxDelay?: number; // Default: 10000ms
+}
+
 export interface GitHubDBConfig {
   accessToken: string;
   owner: string;
   repo: string;
   branch?: string;
   cacheTTL?: number;
+  retry?: RetryConfig | false; // false to disable
 }
 
 export type Schema = Record<string, any>;
@@ -58,6 +65,15 @@ export class ConcurrencyError extends Error {
   constructor(public readonly path: string) {
     super(`Concurrency conflict at ${path}. The remote data has changed.`);
     this.name = "ConcurrencyError";
+  }
+}
+
+export class RateLimitError extends Error {
+  constructor(public readonly retryAfter?: number) {
+    super(
+      `GitHub API rate limit exceeded${retryAfter ? `. Retry after ${retryAfter}s` : ""}`
+    );
+    this.name = "RateLimitError";
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,4 +2,4 @@ export { GitHubDB } from "./ui/github-db.js";
 export { Collection } from "./ui/collection.js";
 export { Transaction } from "./ui/transaction.js";
 export * from "./core/types.js";
-export const version = "1.2.0";
+export const version = "1.3.0";

--- a/src/infrastructure/github-storage.ts
+++ b/src/infrastructure/github-storage.ts
@@ -1,6 +1,8 @@
 import { Octokit } from "@octokit/rest";
 import {
   ConcurrencyError,
+  RateLimitError,
+  RetryConfig,
   GitHubDBConfig,
   IStorageProvider,
   StorageResponse,
@@ -21,12 +23,65 @@ export class GitHubStorageProvider implements IStorageProvider {
     this.cache = cache || new MemoryCacheProvider();
   }
 
+  private async retryWithBackoff<T>(fn: () => Promise<T>): Promise<T> {
+    if (this.config.retry === false) return fn();
+
+    const {
+      maxRetries = 3,
+      baseDelay = 1000,
+      maxDelay = 10000,
+    } = this.config.retry ?? {};
+
+    let lastError: any;
+
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      try {
+        return await fn();
+      } catch (error: any) {
+        lastError = error;
+        const status = error?.status;
+
+        // Non-retryable: 409 (concurrency), 4xx client errors (except 429)
+        if (status === 409) throw error;
+        if (status && status < 500 && status !== 429) throw error;
+        // Errors without a status code (non-HTTP errors) — rethrow
+        if (!status) throw error;
+
+        // Last attempt — don't wait, just break
+        if (attempt === maxRetries) break;
+
+        // Calculate delay
+        let delay: number;
+        if (status === 429 && error.response?.headers?.["retry-after"]) {
+          delay =
+            parseInt(error.response.headers["retry-after"], 10) * 1000;
+        } else {
+          delay = Math.min(baseDelay * Math.pow(2, attempt), maxDelay);
+        }
+
+        await new Promise((resolve) => setTimeout(resolve, delay));
+      }
+    }
+
+    // Exhausted retries on 429 → RateLimitError
+    if (lastError?.status === 429) {
+      const retryAfter = lastError.response?.headers?.["retry-after"];
+      throw new RateLimitError(
+        retryAfter ? parseInt(retryAfter, 10) : undefined
+      );
+    }
+
+    throw lastError;
+  }
+
   async testConnection(): Promise<boolean> {
     try {
-      await this.octokit.repos.get({
-        owner: this.config.owner,
-        repo: this.config.repo,
-      });
+      await this.retryWithBackoff(() =>
+        this.octokit.repos.get({
+          owner: this.config.owner,
+          repo: this.config.repo,
+        })
+      );
       return true;
     } catch (error) {
       return false;
@@ -39,11 +94,13 @@ export class GitHubStorageProvider implements IStorageProvider {
     }
 
     try {
-      await this.octokit.repos.getContent({
-        owner: this.config.owner,
-        repo: this.config.repo,
-        path,
-      });
+      await this.retryWithBackoff(() =>
+        this.octokit.repos.getContent({
+          owner: this.config.owner,
+          repo: this.config.repo,
+          path,
+        })
+      );
       return true;
     } catch (error: any) {
       if (error.status === 404) {
@@ -64,12 +121,14 @@ export class GitHubStorageProvider implements IStorageProvider {
     const stale = this.staleCache.get(path) as StorageResponse<T> | undefined;
 
     try {
-      const response = await this.octokit.repos.getContent({
-        owner: this.config.owner,
-        repo: this.config.repo,
-        path,
-        headers: stale ? { "if-none-match": `"${stale.sha}"` } : {},
-      });
+      const response = await this.retryWithBackoff(() =>
+        this.octokit.repos.getContent({
+          owner: this.config.owner,
+          repo: this.config.repo,
+          path,
+          headers: stale ? { "if-none-match": `"${stale.sha}"` } : {},
+        })
+      );
 
       if (Array.isArray(response.data)) {
         throw new Error("Path is a directory, not a file");
@@ -122,11 +181,13 @@ export class GitHubStorageProvider implements IStorageProvider {
         internalSha = cached.sha;
       } else {
         try {
-          const existing = await this.octokit.repos.getContent({
-            owner: this.config.owner,
-            repo: this.config.repo,
-            path,
-          });
+          const existing = await this.retryWithBackoff(() =>
+            this.octokit.repos.getContent({
+              owner: this.config.owner,
+              repo: this.config.repo,
+              path,
+            })
+          );
 
           if (!Array.isArray(existing.data) && "sha" in existing.data) {
             internalSha = existing.data.sha;
@@ -140,18 +201,22 @@ export class GitHubStorageProvider implements IStorageProvider {
     }
 
     try {
-      const response = await this.octokit.repos.createOrUpdateFileContents({
-        owner: this.config.owner,
-        repo: this.config.repo,
-        path,
-        message,
-        content: btoa(
-          Array.from(new TextEncoder().encode(JSON.stringify(content, null, 2)))
-            .map((b) => String.fromCharCode(b))
-            .join("")
-        ),
-        sha: internalSha,
-      });
+      const response = await this.retryWithBackoff(() =>
+        this.octokit.repos.createOrUpdateFileContents({
+          owner: this.config.owner,
+          repo: this.config.repo,
+          path,
+          message,
+          content: btoa(
+            Array.from(
+              new TextEncoder().encode(JSON.stringify(content, null, 2))
+            )
+              .map((b) => String.fromCharCode(b))
+              .join("")
+          ),
+          sha: internalSha,
+        })
+      );
 
       const newSha = response.data.content?.sha || "";
       const result = { data: content, sha: newSha };
@@ -178,19 +243,23 @@ export class GitHubStorageProvider implements IStorageProvider {
 
     try {
       // 1. Get the current head SHA
-      const { data: ref } = await this.octokit.git.getRef({
-        owner: this.config.owner,
-        repo: this.config.repo,
-        ref: `heads/${branch}`,
-      });
+      const { data: ref } = await this.retryWithBackoff(() =>
+        this.octokit.git.getRef({
+          owner: this.config.owner,
+          repo: this.config.repo,
+          ref: `heads/${branch}`,
+        })
+      );
       const latestCommitSha = ref.object.sha;
 
       // 2. Get the tree SHA of the latest commit
-      const { data: latestCommit } = await this.octokit.git.getCommit({
-        owner: this.config.owner,
-        repo: this.config.repo,
-        commit_sha: latestCommitSha,
-      });
+      const { data: latestCommit } = await this.retryWithBackoff(() =>
+        this.octokit.git.getCommit({
+          owner: this.config.owner,
+          repo: this.config.repo,
+          commit_sha: latestCommitSha,
+        })
+      );
       const baseTreeSha = latestCommit.tree.sha;
 
       // 3. Create a new tree with multiple files
@@ -211,29 +280,35 @@ export class GitHubStorageProvider implements IStorageProvider {
         };
       });
 
-      const { data: newTree } = await this.octokit.git.createTree({
-        owner: this.config.owner,
-        repo: this.config.repo,
-        base_tree: baseTreeSha,
-        tree: treeEntries,
-      });
+      const { data: newTree } = await this.retryWithBackoff(() =>
+        this.octokit.git.createTree({
+          owner: this.config.owner,
+          repo: this.config.repo,
+          base_tree: baseTreeSha,
+          tree: treeEntries,
+        })
+      );
 
       // 4. Create a new commit
-      const { data: newCommit } = await this.octokit.git.createCommit({
-        owner: this.config.owner,
-        repo: this.config.repo,
-        message,
-        tree: newTree.sha,
-        parents: [latestCommitSha],
-      });
+      const { data: newCommit } = await this.retryWithBackoff(() =>
+        this.octokit.git.createCommit({
+          owner: this.config.owner,
+          repo: this.config.repo,
+          message,
+          tree: newTree.sha,
+          parents: [latestCommitSha],
+        })
+      );
 
       // 5. Update the reference
-      await this.octokit.git.updateRef({
-        owner: this.config.owner,
-        repo: this.config.repo,
-        ref: `heads/${branch}`,
-        sha: newCommit.sha,
-      });
+      await this.retryWithBackoff(() =>
+        this.octokit.git.updateRef({
+          owner: this.config.owner,
+          repo: this.config.repo,
+          ref: `heads/${branch}`,
+          sha: newCommit.sha,
+        })
+      );
 
       // 6. Update cache for all involved files
       const ttl = this.config.cacheTTL ?? this.DEFAULT_TTL;
@@ -258,13 +333,15 @@ export class GitHubStorageProvider implements IStorageProvider {
   }
 
   async deleteFile(path: string, message: string, sha: string): Promise<void> {
-    await this.octokit.repos.deleteFile({
-      owner: this.config.owner,
-      repo: this.config.repo,
-      path,
-      message,
-      sha,
-    });
+    await this.retryWithBackoff(() =>
+      this.octokit.repos.deleteFile({
+        owner: this.config.owner,
+        repo: this.config.repo,
+        path,
+        message,
+        sha,
+      })
+    );
     this.cache.delete(path);
     this.staleCache.delete(path);
   }
@@ -273,11 +350,13 @@ export class GitHubStorageProvider implements IStorageProvider {
     path: string
   ): Promise<{ path: string; sha: string; type: "file" | "dir" }[]> {
     try {
-      const response = await this.octokit.repos.getContent({
-        owner: this.config.owner,
-        repo: this.config.repo,
-        path,
-      });
+      const response = await this.retryWithBackoff(() =>
+        this.octokit.repos.getContent({
+          owner: this.config.owner,
+          repo: this.config.repo,
+          path,
+        })
+      );
 
       if (!Array.isArray(response.data)) {
         throw new Error("Path is not a directory");

--- a/tests/retry.test.ts
+++ b/tests/retry.test.ts
@@ -1,0 +1,282 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { GitHubStorageProvider } from "../src/infrastructure/github-storage.js";
+import { ConcurrencyError, RateLimitError } from "../src/core/types.js";
+
+describe("Retry Logic & Rate Limit Handling", () => {
+  const config = {
+    accessToken: "test-token",
+    owner: "test-owner",
+    repo: "test-repo",
+  };
+
+  let storage: GitHubStorageProvider;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    storage = new GitHubStorageProvider(config);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function mockGetContent(mock: ReturnType<typeof vi.fn>) {
+    (storage as any).octokit.repos.getContent = mock;
+  }
+
+  function makeOctokitError(status: number, headers: Record<string, string> = {}) {
+    const error: any = new Error(`HTTP ${status}`);
+    error.status = status;
+    error.response = { headers };
+    return error;
+  }
+
+  describe("Rate Limit Handling", () => {
+    it("should retry on 429 and succeed on subsequent attempt", async () => {
+      const mock = vi
+        .fn()
+        .mockRejectedValueOnce(makeOctokitError(429))
+        .mockResolvedValueOnce({
+          data: {
+            content: btoa(JSON.stringify({ id: "1" })),
+            sha: "abc123",
+          },
+        });
+      mockGetContent(mock);
+
+      const promise = storage.readJson("test.json");
+      // Advance past backoff delay
+      await vi.advanceTimersByTimeAsync(2000);
+
+      const result = await promise;
+      expect(result.data).toEqual({ id: "1" });
+      expect(mock).toHaveBeenCalledTimes(2);
+    });
+
+    it("should respect Retry-After header from 429 response", async () => {
+      const mock = vi
+        .fn()
+        .mockRejectedValueOnce(makeOctokitError(429, { "retry-after": "2" }))
+        .mockResolvedValueOnce({
+          data: {
+            content: btoa(JSON.stringify({ id: "1" })),
+            sha: "abc123",
+          },
+        });
+      mockGetContent(mock);
+
+      const promise = storage.readJson("test.json");
+
+      // At 1s, should not have retried yet (Retry-After is 2s)
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(mock).toHaveBeenCalledTimes(1);
+
+      // At 2s, should retry
+      await vi.advanceTimersByTimeAsync(1000);
+      await vi.advanceTimersByTimeAsync(100); // small buffer for jitter
+
+      const result = await promise;
+      expect(result.data).toEqual({ id: "1" });
+      expect(mock).toHaveBeenCalledTimes(2);
+    });
+
+    it("should throw RateLimitError after max retries exhausted on persistent 429", async () => {
+      const mock = vi.fn().mockImplementation(async () => {
+        throw makeOctokitError(429);
+      });
+      mockGetContent(mock);
+
+      const promise = storage.readJson("test.json");
+      // Attach rejection handler before advancing timers to avoid unhandled rejection
+      const assertion = expect(promise).rejects.toThrow(RateLimitError);
+
+      await vi.runAllTimersAsync();
+
+      await assertion;
+      expect(mock).toHaveBeenCalledTimes(4); // 1 initial + 3 retries
+    });
+  });
+
+  describe("Transient Error Retry", () => {
+    it("should retry on 500/502/503 server errors and succeed", async () => {
+      for (const status of [500, 502, 503]) {
+        const s = new GitHubStorageProvider(config);
+        const mock = vi
+          .fn()
+          .mockRejectedValueOnce(makeOctokitError(status))
+          .mockResolvedValueOnce({
+            data: {
+              content: btoa(JSON.stringify({ ok: true })),
+              sha: "sha1",
+            },
+          });
+        (s as any).octokit.repos.getContent = mock;
+
+        const promise = s.readJson("test.json");
+        await vi.advanceTimersByTimeAsync(2000);
+
+        const result = await promise;
+        expect(result.data).toEqual({ ok: true });
+        expect(mock).toHaveBeenCalledTimes(2);
+      }
+    });
+
+    it("should NOT retry on 401/403/404 (non-transient client errors)", async () => {
+      for (const status of [401, 403, 404]) {
+        const s = new GitHubStorageProvider(config);
+        const mock = vi.fn().mockRejectedValue(makeOctokitError(status));
+        (s as any).octokit.repos.getContent = mock;
+
+        await expect(s.readJson("test.json")).rejects.toThrow();
+        expect(mock).toHaveBeenCalledTimes(1);
+      }
+    });
+
+    it("should NOT retry on 409 (ConcurrencyError should propagate immediately)", async () => {
+      const writeMock = vi.fn().mockRejectedValue(makeOctokitError(409));
+      (storage as any).octokit.repos.createOrUpdateFileContents = writeMock;
+
+      await expect(
+        storage.writeJson("test.json", { id: "1" }, "test commit", "old-sha")
+      ).rejects.toThrow(ConcurrencyError);
+      expect(writeMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("Backoff Behavior", () => {
+    it("should use exponential backoff between retries", async () => {
+      const s = new GitHubStorageProvider({
+        ...config,
+        retry: { baseDelay: 100, maxDelay: 10000 },
+      });
+      const mock = vi
+        .fn()
+        .mockRejectedValueOnce(makeOctokitError(500)) // attempt 0
+        .mockRejectedValueOnce(makeOctokitError(500)) // attempt 1
+        .mockRejectedValueOnce(makeOctokitError(500)) // attempt 2
+        .mockResolvedValueOnce({
+          data: {
+            content: btoa(JSON.stringify({ ok: true })),
+            sha: "sha1",
+          },
+        });
+      (s as any).octokit.repos.getContent = mock;
+
+      const promise = s.readJson("test.json");
+
+      // First retry after ~100ms (baseDelay * 2^0)
+      await vi.advanceTimersByTimeAsync(150);
+      expect(mock).toHaveBeenCalledTimes(2);
+
+      // Second retry after ~200ms (baseDelay * 2^1)
+      await vi.advanceTimersByTimeAsync(250);
+      expect(mock).toHaveBeenCalledTimes(3);
+
+      // Third retry after ~400ms (baseDelay * 2^2)
+      await vi.advanceTimersByTimeAsync(500);
+      expect(mock).toHaveBeenCalledTimes(4);
+
+      const result = await promise;
+      expect(result.data).toEqual({ ok: true });
+    });
+
+    it("should respect maxRetries configuration (default: 3)", async () => {
+      const mock = vi.fn().mockImplementation(async () => {
+        throw makeOctokitError(500);
+      });
+      mockGetContent(mock);
+
+      const promise = storage.readJson("test.json");
+      // Attach rejection handler before advancing timers to avoid unhandled rejection
+      const assertion = expect(promise).rejects.toThrow();
+
+      await vi.runAllTimersAsync();
+
+      await assertion;
+      expect(mock).toHaveBeenCalledTimes(4); // 1 initial + 3 retries
+    });
+  });
+
+  describe("Config", () => {
+    it("should use default retry config when none provided", async () => {
+      const mock = vi
+        .fn()
+        .mockRejectedValueOnce(makeOctokitError(500))
+        .mockResolvedValueOnce({
+          data: {
+            content: btoa(JSON.stringify({ ok: true })),
+            sha: "sha1",
+          },
+        });
+      mockGetContent(mock);
+
+      const promise = storage.readJson("test.json");
+      // Default baseDelay is 1000ms, first retry delay = 1000 * 2^0 = 1000ms
+      await vi.advanceTimersByTimeAsync(1500);
+
+      const result = await promise;
+      expect(result.data).toEqual({ ok: true });
+      expect(mock).toHaveBeenCalledTimes(2);
+    });
+
+    it("should allow disabling retries via retry: false", async () => {
+      const s = new GitHubStorageProvider({
+        ...config,
+        retry: false,
+      });
+      const mock = vi.fn().mockRejectedValue(makeOctokitError(500));
+      (s as any).octokit.repos.getContent = mock;
+
+      await expect(s.readJson("test.json")).rejects.toThrow();
+      expect(mock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("Retry applies to all storage operations", () => {
+    it("should retry testConnection on transient error", async () => {
+      const mock = vi
+        .fn()
+        .mockRejectedValueOnce(makeOctokitError(502))
+        .mockResolvedValueOnce({ data: {} });
+      (storage as any).octokit.repos.get = mock;
+
+      const promise = storage.testConnection();
+      await vi.advanceTimersByTimeAsync(2000);
+
+      const result = await promise;
+      expect(result).toBe(true);
+      expect(mock).toHaveBeenCalledTimes(2);
+    });
+
+    it("should retry deleteFile on transient error", async () => {
+      const mock = vi
+        .fn()
+        .mockRejectedValueOnce(makeOctokitError(503))
+        .mockResolvedValueOnce({});
+      (storage as any).octokit.repos.deleteFile = mock;
+
+      const promise = storage.deleteFile("test.json", "delete", "sha1");
+      await vi.advanceTimersByTimeAsync(2000);
+
+      await promise;
+      expect(mock).toHaveBeenCalledTimes(2);
+    });
+
+    it("should retry listDirectory on transient error", async () => {
+      const mock = vi
+        .fn()
+        .mockRejectedValueOnce(makeOctokitError(500))
+        .mockResolvedValueOnce({
+          data: [{ path: "file.json", sha: "sha1", type: "file" }],
+        });
+      mockGetContent(mock);
+
+      const promise = storage.listDirectory("data/");
+      await vi.advanceTimersByTimeAsync(2000);
+
+      const result = await promise;
+      expect(result).toHaveLength(1);
+      expect(mock).toHaveBeenCalledTimes(2);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add `RetryConfig` type and `RateLimitError` class to `src/core/types.ts`
- Implement `retryWithBackoff` helper in `GitHubStorageProvider` wrapping all Octokit API calls
- Automatically retry on transient errors (429, 500, 502, 503) with exponential backoff
- Respect `Retry-After` header from GitHub 429 responses
- Throw `RateLimitError` when retries are exhausted on persistent rate limiting
- Non-transient errors (401, 403, 404, 409) propagate immediately — no behavioral change
- Configurable via `retry` option on `GitHubDBConfig` (or `false` to disable)
- 13 new tests, all 108 tests passing, no regressions

## Test plan

- [x] All 18 existing test files still pass (95 pre-existing tests)
- [x] New `tests/retry.test.ts` passes (13 tests)
- [x] TypeScript build succeeds
- [x] No breaking changes — `retry` config is optional, defaults to 3 retries