### PR TITLE
fix: add missing strategy option to GitHubDB.collection()

### DIFF
--- a/src/ui/github-db.ts
+++ b/src/ui/github-db.ts
@@ -3,6 +3,7 @@ import {
   IStorageProvider,
   Middleware,
   Schema,
+  StorageStrategy,
   Validator,
 } from "../core/types.js";
 import { GitHubStorageProvider } from "../infrastructure/github-storage.js";
@@ -33,7 +34,7 @@ export class GitHubDB {
 
   collection<T extends Schema>(
     name: string,
-    options: { middleware?: Middleware<T>[]; validator?: Validator<T> } = {}
+    options: { middleware?: Middleware<T>[]; validator?: Validator<T>; strategy?: StorageStrategy } = {}
   ): Collection<T> {
     return new Collection<T>(name, this.storage, options);
   }


### PR DESCRIPTION
## Summary

- Add `StorageStrategy` to the `GitHubDB.collection()` options type so users can pass `strategy` through the main entry point

The `Collection` constructor already supports the `strategy` option, but it was missing from the `GitHubDB.collection()` method signature, causing TypeScript errors when trying to configure sharding via the public API.

Supersedes #2, which identified the same gap but was outdated against main.

## Test plan

- [x] All 108 tests passing
- [x] TypeScript build succeeds